### PR TITLE
Comment out City Apotek logo in footer

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -132,12 +132,12 @@
         class="h-6 sm:h-7 md:h-8 w-auto object-contain opacity-85"
         loading="lazy"
       />
-      <img
+      <!-- <img
         src="/pictures/Logos/CityApotekLogo1.webp"
         alt="City Apotek"
         class="h-6 sm:h-7 md:h-8 w-auto object-contain opacity-85"
         loading="lazy"
-      />
+      /> -->
       <img
         src="/pictures/Logos/technovital_logo_org.webp"
         alt="Technovital"


### PR DESCRIPTION
Temporarily commented out the City Apotek <img> element in src/sections/Footer.astro by wrapping the tag in an HTML comment. Keeps the image markup in place for easy restoration while hiding it from the rendered footer.