### PR TITLE
Update services link to Bokadirekt

### DIFF
--- a/src/sections/Services.astro
+++ b/src/sections/Services.astro
@@ -39,7 +39,7 @@
         </p>
         <div class="mt-6">
           <a
-            href="/services"
+            href="https://www.bokadirekt.se/places/zaras-halsofokus-40836"
             class="inline-block px-6 py-3 rounded-md border border-white/40 bg-white/15 text-white hover:bg-white/25 hover:border-white/60 transition"
           >
             Läs mer om Tjänster


### PR DESCRIPTION
Replace the internal /services href with the external Bokadirekt booking URL (https://www.bokadirekt.se/places/zaras-halsofokus-40836) for the "Läs mer om Tjänster" button. Styling and classes are unchanged; this points users directly to the booking page.