### PR TITLE
Remove standalone booking CTA

### DIFF
--- a/src/pages/aboutUs.astro
+++ b/src/pages/aboutUs.astro
@@ -551,14 +551,9 @@ import Layout from "../layouts/Layout.astro";
         Boka din behandling idag och upplev skillnaden.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        
         <a
           href="https://www.bokadirekt.se/places/zaras-halsofokus-40836"
-          class="px-6 py-3 rounded-md bg-[#2f2011] text-white hover:bg-[#2f2011]/85 transition font-medium"
-        >
-          Boka behandling
-        </a>
-        <a
-          href="/#services"
           class="px-6 py-3 rounded-md border border-[#2f2011]/40 bg-white/60 text-[#2f2011] hover:bg-white transition font-medium"
         >
           Se våra tjänster


### PR DESCRIPTION
Remove the separate 'Boka behandling' anchor in src/pages/aboutUs.astro and consolidate into a single CTA. The markup was changed so only one button remains; it now uses the existing anchor markup and links to the external booking URL while displaying 'Se våra tjänster'.